### PR TITLE
Feat/add linear support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `release-summary` mode summarises code changes released between workflow run
 
 <img src="docs/release_summary_example.png" alt="Release summary example" width="650">
 
-It can also integrate with **Jira** to include titles and links for any issue numbers found in associated pull requests, branch names, or commit messages.
+It can also integrate with **Jira** or **Linear** to include titles and links for any issue keys found in associated pull requests, branch names, or commit messages.
 
 ### **Usage**
 
@@ -58,6 +58,10 @@ with:
   # Jira instance base URL (e.g., https://my-company.atlassian.net).
   # Required if `jira_api_key` is provided.
   jira_base_url: ""
+
+  # Linear API key with read permissions.
+  # Required for Linear integration.
+  linear_api_key: ""
 
   # Slack webhook URL for the release summary.
   # Required for 'release-summary' mode.
@@ -113,7 +117,7 @@ If `paths` is not provided, Anno will use the workflow file's `on.push` paths. I
 
 ## Pull Request Summaries
 
-The `pr-summary` mode adds a very brief summary of pull requests to their descriptions. It can also link to and use any Jira tickets found referenced in the branch name and commit messages as additional context.
+The `pr-summary` mode adds a very brief summary of pull requests to their descriptions. It can also link to and use any Jira or Linear tickets found referenced in the branch name and commit messages as additional context.
 
 <img src="docs/pr_summary_example.png" alt="PR summary example" width="750">
 
@@ -167,4 +171,8 @@ jobs:
           # Jira instance base URL (e.g., https://my-company.atlassian.net).
           # Required if `jira_api_key` is provided.
           jira_base_url: ""
+
+          # Linear API key with read permissions.
+          # Required for Linear integration.
+          linear_api_key: ""
 ```

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   jira_base_url:
     description: Base URL of your Jira instance, e.g. https://my-company.atlassian.net. Required if Jira is enabled.
     required: false
+  linear_api_key:
+    description: Linear API key with read permissions. Required if Linear is enabled.
+    required: false
   slack_webhook_url:
     description: Slack webhook URL for the release summary.
     required: false
@@ -85,6 +88,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         JIRA_API_KEY: ${{ inputs.jira_api_key }}
         JIRA_BASE_URL: ${{ inputs.jira_base_url }}
+        LINEAR_API_KEY: ${{ inputs.linear_api_key }}
         MODE: ${{ inputs.mode }}
         PATHS: ${{ inputs.paths }}
         REPOS_DIR: ./repos

--- a/src/ai/pr_summary.rs
+++ b/src/ai/pr_summary.rs
@@ -1,5 +1,6 @@
 use crate::ai::{AiProvider, AiRequest};
 use crate::services::jira::Issue;
+use crate::services::linear::Issue as LinearIssue;
 use anyhow::Result;
 use serde::Deserialize;
 use serde_json::json;
@@ -15,6 +16,7 @@ impl PrSummary {
         diff: &str,
         commit_messages: &[String],
         issues: &[Issue],
+        linear_issues: &[LinearIssue],
     ) -> Result<Self> {
         tracing::info!("Generating PR summary");
 
@@ -32,11 +34,25 @@ impl PrSummary {
             })
             .collect::<Vec<String>>()
             .join("\n");
+        let linear_issues = linear_issues
+            .iter()
+            .filter(|i| i.description.is_some())
+            .map(|i| {
+                format!(
+                    "- [{}] {}\n{}",
+                    i.identifier,
+                    i.title,
+                    i.description.as_deref().unwrap_or_default()
+                )
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
 
         let user_prompt = format!(
             "<Diff>{diff}</Diff>
              <CommitMessages>{commit_messages}</CommitMessages>
-             <JiraIssues>{issues}</JiraIssues>"
+             <JiraIssues>{issues}</JiraIssues>
+             <LinearIssues>{linear_issues}</LinearIssues>"
         );
 
         let result: Self = provider
@@ -63,7 +79,7 @@ impl PrSummary {
 const SYSTEM_PROMPT: &str = "
     <Instructions>
         Your task is to summarise a pull request to make it easier for other team members to understand the changes before reviewing.
-        Use the diff, commit messages, and Jira issues (if provided) to summarise the code changes and how they relate to the feature or bug described in the issues.
+        Use the diff, commit messages, and any Jira or Linear issues (if provided) to summarise the code changes and how they relate to the feature or bug described in the issues.
         Keep your summary very short, clear and concise so that it provides a high-level overview of the changes and their impact.
         Use direct language and avoid redundant phrases; the fewer words you use, the clearer your summary will be.
         Avoid including any personal opinions or feedback in your summary, as this is a factual summary of the changes.
@@ -72,7 +88,7 @@ const SYSTEM_PROMPT: &str = "
     <Steps>
         - Review the diff to understand the changes made in the pull request.
         - Review the commit messages to understand the context of the changes.
-        - Review the Jira issues to understand the feature or bug being addressed.
+        - Review the Jira and Linear issues to understand the feature or bug being addressed.
         - Write a summary that explains the changes made in the pull request and how they relate to the feature or bug.
         - Keep your summary clear and concise, focusing on the high-level changes made in the pull request.
         - Provide the summary without any personal opinions or feedback, as this is a factual summary of the changes.

--- a/src/ai/pr_summary.rs
+++ b/src/ai/pr_summary.rs
@@ -1,6 +1,6 @@
 use crate::ai::{AiProvider, AiRequest};
-use crate::services::jira::Issue;
-use crate::services::linear::Issue as LinearIssue;
+use crate::services::jira::JiraIssue;
+use crate::services::linear::LinearIssue;
 use anyhow::Result;
 use serde::Deserialize;
 use serde_json::json;
@@ -15,7 +15,7 @@ impl PrSummary {
         provider: AiProvider,
         diff: &str,
         commit_messages: &[String],
-        issues: &[Issue],
+        issues: &[JiraIssue],
         linear_issues: &[LinearIssue],
     ) -> Result<Self> {
         tracing::info!("Generating PR summary");

--- a/src/modes/pull_request.rs
+++ b/src/modes/pull_request.rs
@@ -2,8 +2,8 @@ use crate::{
     ai::{self, AiProvider},
     services::{
         github::{GitHubClient, PullRequest},
-        jira::Issue,
-        linear::Issue as LinearIssue,
+        jira::JiraIssue,
+        linear::LinearIssue,
     },
     utils::{env, issue_keys},
 };
@@ -50,7 +50,7 @@ async fn generate_and_set_summary(
     Ok(())
 }
 
-async fn get_jira_issues(pr: &PullRequest) -> Result<Vec<Issue>> {
+async fn get_jira_issues(pr: &PullRequest) -> Result<Vec<JiraIssue>> {
     let jira_enabled = env::get_optional("JIRA_API_KEY").is_some();
 
     if !jira_enabled {
@@ -63,7 +63,7 @@ async fn get_jira_issues(pr: &PullRequest) -> Result<Vec<Issue>> {
     let keys = issue_keys::extract_issue_keys(&branches, &bodies, &[]);
 
     let mut issues: Vec<_> = stream::iter(keys)
-        .map(async |key| Issue::get_by_key(&key).await)
+        .map(async |key| JiraIssue::get_by_key(&key).await)
         .buffer_unordered(5)
         .try_collect::<Vec<_>>()
         .await?
@@ -105,7 +105,7 @@ async fn get_linear_issues(pr: &PullRequest) -> Result<Vec<LinearIssue>> {
 fn get_pr_body(
     summary: &ai::PrSummary,
     pr: &PullRequest,
-    issues: &[Issue],
+    issues: &[JiraIssue],
     linear_issues: &[LinearIssue],
     jira_base_url: Option<&str>,
 ) -> String {
@@ -159,8 +159,8 @@ mod tests {
         serde_json::from_value(json!({ "summary": text })).unwrap()
     }
 
-    fn make_issue(key: &str, summary: &str) -> Issue {
-        Issue {
+    fn make_issue(key: &str, summary: &str) -> JiraIssue {
+        JiraIssue {
             key: key.to_string(),
             fields: crate::services::jira::IssueFields {
                 summary: summary.to_string(),

--- a/src/modes/pull_request.rs
+++ b/src/modes/pull_request.rs
@@ -3,8 +3,9 @@ use crate::{
     services::{
         github::{GitHubClient, PullRequest},
         jira::Issue,
+        linear::Issue as LinearIssue,
     },
-    utils::{env, jira as jira_utils},
+    utils::{env, issue_keys},
 };
 use anyhow::{Context, Result};
 use std::fmt::Write;
@@ -37,11 +38,13 @@ async fn generate_and_set_summary(
     let diff = pr.get_diff(gh).await?;
     let commit_messages = pr.get_commit_messages(gh).await?;
     let issues = get_jira_issues(&pr).await?;
+    let linear_issues = get_linear_issues(&pr).await?;
 
-    let summary = ai::PrSummary::new(provider, &diff, &commit_messages, &issues).await?;
+    let summary =
+        ai::PrSummary::new(provider, &diff, &commit_messages, &issues, &linear_issues).await?;
 
     let jira_base_url = env::get_optional("JIRA_BASE_URL");
-    let pr_body = get_pr_body(&summary, &pr, &issues, jira_base_url.as_deref());
+    let pr_body = get_pr_body(&summary, &pr, &issues, &linear_issues, jira_base_url.as_deref());
     pr.set_body(gh, pr_body).await?;
 
     Ok(())
@@ -57,7 +60,7 @@ async fn get_jira_issues(pr: &PullRequest) -> Result<Vec<Issue>> {
     let branches = [pr.head.r#ref.as_str()];
     let bodies: Vec<&str> = pr.body.as_deref().into_iter().collect();
 
-    let keys = jira_utils::extract_issue_keys(&branches, &bodies, &[]);
+    let keys = issue_keys::extract_issue_keys(&branches, &bodies, &[]);
 
     let mut issues: Vec<_> = stream::iter(keys)
         .map(async |key| Issue::get_by_key(&key).await)
@@ -73,10 +76,37 @@ async fn get_jira_issues(pr: &PullRequest) -> Result<Vec<Issue>> {
     Ok(issues)
 }
 
+async fn get_linear_issues(pr: &PullRequest) -> Result<Vec<LinearIssue>> {
+    let linear_enabled = env::get_optional("LINEAR_API_KEY").is_some();
+
+    if !linear_enabled {
+        return Ok(Vec::new());
+    }
+
+    let branches = [pr.head.r#ref.as_str()];
+    let bodies: Vec<&str> = pr.body.as_deref().into_iter().collect();
+
+    let keys = issue_keys::extract_issue_keys(&branches, &bodies, &[]);
+
+    let mut issues: Vec<_> = stream::iter(keys)
+        .map(async |key| LinearIssue::get_by_key(&key).await)
+        .buffer_unordered(5)
+        .try_collect::<Vec<_>>()
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
+
+    issues.sort_by(|a, b| a.identifier.cmp(&b.identifier));
+
+    Ok(issues)
+}
+
 fn get_pr_body(
     summary: &ai::PrSummary,
     pr: &PullRequest,
     issues: &[Issue],
+    linear_issues: &[LinearIssue],
     jira_base_url: Option<&str>,
 ) -> String {
     let mut body = String::new();
@@ -85,7 +115,7 @@ fn get_pr_body(
         body = format!("{existing_body}<hr>\n{body}\n");
     }
 
-    if !issues.is_empty() {
+    if !issues.is_empty() || !linear_issues.is_empty() {
         body.push_str("**Tickets**\n");
 
         for issue in issues {
@@ -94,6 +124,10 @@ fn get_pr_body(
                 "- {}",
                 issue.get_github_hyperlink(jira_base_url.unwrap_or_default())
             );
+        }
+
+        for issue in linear_issues {
+            let _ = writeln!(body, "- {}", issue.get_github_hyperlink());
         }
     }
 
@@ -135,11 +169,20 @@ mod tests {
         }
     }
 
+    fn make_linear_issue(identifier: &str, title: &str) -> LinearIssue {
+        LinearIssue {
+            identifier: identifier.to_string(),
+            title: title.to_string(),
+            description: None,
+            url: format!("https://linear.app/acme/issue/{identifier}"),
+        }
+    }
+
     #[test]
     fn body_with_no_existing_body_no_issues() {
         let pr = make_pr(None);
         let summary = make_summary("Changes were made");
-        let result = get_pr_body(&summary, &pr, &[], None);
+        let result = get_pr_body(&summary, &pr, &[], &[], None);
         assert_eq!(result, "**Summary**\n\nChanges were made");
     }
 
@@ -147,7 +190,7 @@ mod tests {
     fn body_prepends_existing_body() {
         let pr = make_pr(Some("Existing description"));
         let summary = make_summary("Changes were made");
-        let result = get_pr_body(&summary, &pr, &[], None);
+        let result = get_pr_body(&summary, &pr, &[], &[], None);
         assert!(result.starts_with("Existing description<hr>"));
         assert!(result.contains("**Summary**\n\nChanges were made"));
     }
@@ -160,7 +203,7 @@ mod tests {
             make_issue("PROJ-1", "First"),
             make_issue("PROJ-2", "Second"),
         ];
-        let result = get_pr_body(&summary, &pr, &issues, Some("https://jira.example.com"));
+        let result = get_pr_body(&summary, &pr, &issues, &[], Some("https://jira.example.com"));
         assert!(result.contains("**Tickets**"));
         assert!(result.contains("PROJ-1 - First"));
         assert!(result.contains("PROJ-2 - Second"));
@@ -172,8 +215,24 @@ mod tests {
         let pr = make_pr(None);
         let summary = make_summary("Changes were made");
         let issues = vec![make_issue("PROJ-1", "First")];
-        let result = get_pr_body(&summary, &pr, &issues, None);
+        let result = get_pr_body(&summary, &pr, &issues, &[], None);
         assert!(result.contains("PROJ-1 - First"));
         assert!(result.contains("/browse/PROJ-1"));
+    }
+
+    #[test]
+    fn body_includes_linear_tickets() {
+        let pr = make_pr(None);
+        let summary = make_summary("Changes were made");
+        let linear_issues = vec![
+            make_linear_issue("ENG-1", "First"),
+            make_linear_issue("ENG-2", "Second"),
+        ];
+        let result = get_pr_body(&summary, &pr, &[], &linear_issues, None);
+        assert!(result.contains("**Tickets**"));
+        assert!(result.contains("ENG-1 - First"));
+        assert!(result.contains("ENG-2 - Second"));
+        assert!(result.contains("https://linear.app/acme/issue/ENG-1"));
+        assert!(result.contains("**Summary**\n\nChanges were made"));
     }
 }

--- a/src/modes/release.rs
+++ b/src/modes/release.rs
@@ -6,15 +6,16 @@ use crate::{
             workflows::{PrevRuns, WorkflowConfig, WorkflowRun, WorkflowRuns},
         },
         jira::Issue,
+        linear::Issue as LinearIssue,
         slack,
     },
     utils::{
-        diff::DiffStats, env, git::Git, github as github_utils, jira as jira_utils,
+        diff::DiffStats, env, git::Git, github as github_utils, issue_keys,
         target_paths::TargetPaths,
     },
 };
 use anyhow::Result;
-use futures::future::{try_join3, try_join4};
+use futures::future::{try_join4, try_join5};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use std::collections::HashSet;
 
@@ -90,8 +91,9 @@ async fn summarise_default_branch(
         .filter_map(PrContext::from_pr)
         .collect();
 
-    let (jira_issues, github_issues, contributors, summary) = try_join4(
+    let (jira_issues, linear_issues, github_issues, contributors, summary) = try_join5(
         get_jira_issues(&pull_requests, &commit_messages),
+        get_linear_issues(&pull_requests, &commit_messages),
         get_github_issues(gh, &repo.full_name, &pull_requests, &commit_messages),
         repo.get_contributors_between_commits(gh, old_commit, new_commit),
         ai::ReleaseSummary::new(provider, &diff, &commit_messages, &pr_contexts),
@@ -113,6 +115,7 @@ async fn summarise_default_branch(
         contributors,
         github_issues,
         jira_issues,
+        linear_issues,
         pull_requests,
         run: &run,
         summary,
@@ -150,8 +153,9 @@ async fn summarise_non_default_branch(
         .filter_map(PrContext::from_pr)
         .collect();
 
-    let (jira_issues, github_issues, summary) = try_join3(
+    let (jira_issues, linear_issues, github_issues, summary) = try_join4(
         get_jira_issues(&pull_requests, commit_messages),
+        get_linear_issues(&pull_requests, commit_messages),
         get_github_issues(gh, &repo.full_name, &pull_requests, commit_messages),
         ai::ReleaseSummary::new(provider, &diff, commit_messages, &pr_contexts),
     )
@@ -168,6 +172,7 @@ async fn summarise_non_default_branch(
         contributors,
         github_issues,
         jira_issues,
+        linear_issues,
         pull_requests,
         run: &run,
         summary,
@@ -224,7 +229,7 @@ async fn get_jira_issues(
         .filter_map(|pr| pr.body.as_deref())
         .collect();
 
-    let keys = jira_utils::extract_issue_keys(&branches, &bodies, commit_messages);
+    let keys = issue_keys::extract_issue_keys(&branches, &bodies, commit_messages);
 
     let mut issues: Vec<_> = stream::iter(keys)
         .map(async |key| Issue::get_by_key(&key).await)
@@ -236,6 +241,41 @@ async fn get_jira_issues(
         .collect();
 
     issues.sort_by(|a, b| a.key.cmp(&b.key));
+
+    Ok(issues)
+}
+
+async fn get_linear_issues(
+    pull_requests: &[PullRequest],
+    commit_messages: &[String],
+) -> Result<Vec<LinearIssue>> {
+    let linear_enabled = env::get_optional("LINEAR_API_KEY").is_some();
+
+    if !linear_enabled {
+        return Ok(Vec::new());
+    }
+
+    let branches: Vec<&str> = pull_requests
+        .iter()
+        .map(|pr| pr.head.r#ref.as_str())
+        .collect();
+    let bodies: Vec<&str> = pull_requests
+        .iter()
+        .filter_map(|pr| pr.body.as_deref())
+        .collect();
+
+    let keys = issue_keys::extract_issue_keys(&branches, &bodies, commit_messages);
+
+    let mut issues: Vec<_> = stream::iter(keys)
+        .map(async |key| LinearIssue::get_by_key(&key).await)
+        .buffer_unordered(5)
+        .try_collect::<Vec<_>>()
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
+
+    issues.sort_by(|a, b| a.identifier.cmp(&b.identifier));
 
     Ok(issues)
 }

--- a/src/modes/release.rs
+++ b/src/modes/release.rs
@@ -5,8 +5,8 @@ use crate::{
             GitHubClient, GitHubIssue, PullRequest, Repository,
             workflows::{PrevRuns, WorkflowConfig, WorkflowRun, WorkflowRuns},
         },
-        jira::Issue,
-        linear::Issue as LinearIssue,
+        jira::JiraIssue,
+        linear::LinearIssue,
         slack,
     },
     utils::{
@@ -213,7 +213,7 @@ async fn get_pull_requests(
 async fn get_jira_issues(
     pull_requests: &[PullRequest],
     commit_messages: &[String],
-) -> Result<Vec<Issue>> {
+) -> Result<Vec<JiraIssue>> {
     let jira_enabled = env::get_optional("JIRA_API_KEY").is_some();
 
     if !jira_enabled {
@@ -232,7 +232,7 @@ async fn get_jira_issues(
     let keys = issue_keys::extract_issue_keys(&branches, &bodies, commit_messages);
 
     let mut issues: Vec<_> = stream::iter(keys)
-        .map(async |key| Issue::get_by_key(&key).await)
+        .map(async |key| JiraIssue::get_by_key(&key).await)
         .buffer_unordered(5)
         .try_collect::<Vec<_>>()
         .await?

--- a/src/services/jira.rs
+++ b/src/services/jira.rs
@@ -3,12 +3,12 @@ use anyhow::Result;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
-pub struct Issue {
+pub struct JiraIssue {
     pub key: String,
     pub fields: IssueFields,
 }
 
-impl Issue {
+impl JiraIssue {
     pub async fn get_by_key(key: &str) -> Result<Option<Self>> {
         let jira_base_url = env::get("JIRA_BASE_URL")?;
         let jira_api_key = env::get("JIRA_API_KEY")?;
@@ -67,8 +67,8 @@ pub struct IssueFields {
 mod tests {
     use super::*;
 
-    fn make_issue(key: &str, summary: &str) -> Issue {
-        Issue {
+    fn make_issue(key: &str, summary: &str) -> JiraIssue {
+        JiraIssue {
             key: key.to_string(),
             fields: IssueFields {
                 summary: summary.to_string(),

--- a/src/services/linear.rs
+++ b/src/services/linear.rs
@@ -1,0 +1,90 @@
+use crate::utils::{env, http};
+use anyhow::Result;
+use serde::Deserialize;
+use serde_json::json;
+
+const LINEAR_API_URL: &str = "https://api.linear.app/graphql";
+
+#[derive(Deserialize)]
+pub struct Issue {
+    pub identifier: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub url: String,
+}
+
+#[derive(Deserialize)]
+struct GraphQlResponse {
+    data: Option<GraphQlData>,
+}
+
+#[derive(Deserialize)]
+struct GraphQlData {
+    issue: Option<Issue>,
+}
+
+impl Issue {
+    pub async fn get_by_key(key: &str) -> Result<Option<Self>> {
+        let linear_api_key = env::get("LINEAR_API_KEY")?;
+
+        tracing::info!("Fetching Linear issue {key}");
+
+        let query = json!({
+            "query": "query IssueByIdentifier($id: String!) { issue(id: $id) { identifier title description url } }",
+            "variables": { "id": key },
+        });
+
+        let response = http::send_with_retry(|| {
+            http::client()
+                .post(LINEAR_API_URL)
+                .header("Content-Type", "application/json")
+                .header("Authorization", &linear_api_key)
+                .json(&query)
+        })
+        .await?
+        .error_for_status()
+        .inspect_err(|err| tracing::error!("Error fetching Linear issue: {err}"))?;
+
+        // Linear returns HTTP 200 with a null issue when the key does not exist,
+        // so a missing/typo'd key resolves to `None` rather than failing the run.
+        let body = response.json::<GraphQlResponse>().await?;
+
+        Ok(body.data.and_then(|data| data.issue))
+    }
+
+    pub fn get_github_hyperlink(&self) -> String {
+        format!("[{} - {}]({})\n", self.identifier, self.title.trim(), self.url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_issue(identifier: &str, title: &str) -> Issue {
+        Issue {
+            identifier: identifier.to_string(),
+            title: title.to_string(),
+            description: None,
+            url: format!("https://linear.app/acme/issue/{identifier}"),
+        }
+    }
+
+    #[test]
+    fn github_hyperlink() {
+        let issue = make_issue("ENG-123", "Fix bug");
+        assert_eq!(
+            issue.get_github_hyperlink(),
+            "[ENG-123 - Fix bug](https://linear.app/acme/issue/ENG-123)\n"
+        );
+    }
+
+    #[test]
+    fn github_hyperlink_trims_title() {
+        let issue = make_issue("ENG-123", "  Fix bug  ");
+        assert_eq!(
+            issue.get_github_hyperlink(),
+            "[ENG-123 - Fix bug](https://linear.app/acme/issue/ENG-123)\n"
+        );
+    }
+}

--- a/src/services/linear.rs
+++ b/src/services/linear.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 const LINEAR_API_URL: &str = "https://api.linear.app/graphql";
 
 #[derive(Deserialize)]
-pub struct Issue {
+pub struct LinearIssue {
     pub identifier: String,
     pub title: String,
     pub description: Option<String>,
@@ -20,10 +20,10 @@ struct GraphQlResponse {
 
 #[derive(Deserialize)]
 struct GraphQlData {
-    issue: Option<Issue>,
+    issue: Option<LinearIssue>,
 }
 
-impl Issue {
+impl LinearIssue {
     pub async fn get_by_key(key: &str) -> Result<Option<Self>> {
         let linear_api_key = env::get("LINEAR_API_KEY")?;
 
@@ -61,8 +61,8 @@ impl Issue {
 mod tests {
     use super::*;
 
-    fn make_issue(identifier: &str, title: &str) -> Issue {
-        Issue {
+    fn make_issue(identifier: &str, title: &str) -> LinearIssue {
+        LinearIssue {
             identifier: identifier.to_string(),
             title: title.to_string(),
             description: None,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod anthropic;
 pub mod github;
 pub mod jira;
+pub mod linear;
 pub mod openai;
 pub mod slack;

--- a/src/services/slack.rs
+++ b/src/services/slack.rs
@@ -2,6 +2,7 @@ use crate::ai;
 use crate::services::{
     github::{CommitAuthor, GitHubIssue, PullRequest, workflows::WorkflowRun},
     jira::Issue,
+    linear::Issue as LinearIssue,
 };
 use crate::utils::{diff::DiffStats, env, http};
 use anyhow::Error;
@@ -13,6 +14,7 @@ pub struct ReleaseSummary<'a> {
     pub jira_base_url: Option<String>,
     pub github_issues: Vec<GitHubIssue>,
     pub jira_issues: Vec<Issue>,
+    pub linear_issues: Vec<LinearIssue>,
     pub diff_url: String,
     pub diff_stats: DiffStats,
     pub compare_to_default_branch_url: String,
@@ -40,6 +42,7 @@ impl ReleaseSummary<'_> {
         message_blocks.extend(self.get_summary_block());
 
         if !self.jira_issues.is_empty()
+            || !self.linear_issues.is_empty()
             || !self.github_issues.is_empty()
             || !self.pull_requests.is_empty()
         {
@@ -56,6 +59,10 @@ impl ReleaseSummary<'_> {
 
         if !self.jira_issues.is_empty() {
             message_blocks.push(self.get_jira_tickets_block());
+        }
+
+        if !self.linear_issues.is_empty() {
+            message_blocks.push(self.get_linear_tickets_block());
         }
 
         message_blocks.push(self.get_actions_block());
@@ -224,6 +231,45 @@ impl ReleaseSummary<'_> {
                                     "type": "link",
                                     "text": format!("{} {}", issue.key, issue.fields.summary),
                                     "url": issue.get_browse_url(self.jira_base_url.as_deref().unwrap_or_default()),
+                                }
+                            ]
+                        })
+                    })
+                    .collect::<Vec<_>>()
+                }
+            ]
+        })
+    }
+
+    fn get_linear_tickets_block(&self) -> Value {
+        json!({
+            "type": "rich_text",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Linear tickets",
+                            "style": {
+                                "bold": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "rich_text_list",
+                    "style": "bullet",
+                    "elements": self.linear_issues
+                    .iter()
+                    .map(|issue| {
+                        json!({
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "link",
+                                    "text": format!("{} {}", issue.identifier, issue.title),
+                                    "url": issue.url,
                                 }
                             ]
                         })

--- a/src/services/slack.rs
+++ b/src/services/slack.rs
@@ -1,8 +1,8 @@
 use crate::ai;
 use crate::services::{
     github::{CommitAuthor, GitHubIssue, PullRequest, workflows::WorkflowRun},
-    jira::Issue,
-    linear::Issue as LinearIssue,
+    jira::JiraIssue,
+    linear::LinearIssue,
 };
 use crate::utils::{diff::DiffStats, env, http};
 use anyhow::Error;
@@ -13,7 +13,7 @@ pub struct ReleaseSummary<'a> {
     pub app_name: String,
     pub jira_base_url: Option<String>,
     pub github_issues: Vec<GitHubIssue>,
-    pub jira_issues: Vec<Issue>,
+    pub jira_issues: Vec<JiraIssue>,
     pub linear_issues: Vec<LinearIssue>,
     pub diff_url: String,
     pub diff_stats: DiffStats,

--- a/src/utils/issue_keys.rs
+++ b/src/utils/issue_keys.rs
@@ -2,10 +2,9 @@ use regex_lite::Regex;
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
-static JIRA_KEY_RE: LazyLock<Regex> =
+static ISSUE_KEY_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)\b([A-Z]{2,10}-\d+)\b").unwrap());
 
-/// Extract unique Jira issue keys from PR branches, bodies, and commit messages.
 pub fn extract_issue_keys(
     branches: &[&str],
     bodies: &[&str],
@@ -14,19 +13,19 @@ pub fn extract_issue_keys(
     let mut keys = HashSet::new();
 
     for branch in branches {
-        if let Some(m) = JIRA_KEY_RE.find(branch) {
+        if let Some(m) = ISSUE_KEY_RE.find(branch) {
             keys.insert(m.as_str().to_uppercase());
         }
     }
 
     for body in bodies {
-        for m in JIRA_KEY_RE.find_iter(body) {
+        for m in ISSUE_KEY_RE.find_iter(body) {
             keys.insert(m.as_str().to_uppercase());
         }
     }
 
     for message in commit_messages {
-        for m in JIRA_KEY_RE.find_iter(message) {
+        for m in ISSUE_KEY_RE.find_iter(message) {
             keys.insert(m.as_str().to_uppercase());
         }
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,5 +3,5 @@ pub mod env;
 pub mod git;
 pub mod github;
 pub mod http;
-pub mod jira;
+pub mod issue_keys;
 pub mod target_paths;


### PR DESCRIPTION
**Summary**

Adds Linear integration alongside existing Jira support. Introduces a new `linear_api_key` input parameter and `LINEAR_API_KEY` environment variable. Implements `LinearIssue` struct with GraphQL API integration to fetch issue details by identifier. Updates PR and release summary modes to extract, fetch, and display Linear issues from branch names, commit messages, and PR bodies. Renames `Issue` to `JiraIssue` for clarity and renames `jira.rs` utility to `issue_keys.rs` since it now handles both Jira and Linear key extraction. Updates documentation and Slack notifications to include Linear tickets.